### PR TITLE
Replace golang:1.13 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,48 @@
-# Build the binary
-FROM golang:1.13 as builder
+FROM container-registry.oracle.com/os/oraclelinux:7-slim AS build_base
 
-WORKDIR /
+LABEL maintainer = "Verrazzano developers <verrazzano_ww@oracle.com>"
+ENV GOBIN=/usr/bin
+ENV GOPATH=/go
+RUN set -eux; \
+    yum update -y ; \
+    yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true ; \
+    yum install -y oracle-golang-release-el7 ; \
+    yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/golang113/x86_64 ; \
+	yum install -y \
+        git \
+        gcc \
+        make \
+        golang-1.13.3-1.el7 \
+	; \
+    yum clean all ; \
+    go version ; \
+	rm -rf /var/cache/yum
+
+# Need to use specific WORKDIR to match node_exporter's source packages
+WORKDIR /go/src/github.com/verrazzano/prometheus-pusher
+
+# Make sure modules are enabled
+ENV GO111MODULE=on
+
+# Fetch all the dependencies
+COPY go.mod .
+COPY go.sum .
+#RUN go clean -modcache
+RUN go mod download 
+
+
+FROM build_base AS builder
 COPY . .
-RUN make unit-test
-RUN make build
 
-FROM oraclelinux:7-slim
+RUN set -eux; \
+    make unit-test; \
+    make build;
+
+
+FROM container-registry.oracle.com/os/oraclelinux:7-slim
 
 RUN yum update -y && \
+    yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true && \
     yum install -y curl && \
     yum clean all
 
@@ -21,4 +55,4 @@ RUN chown -R 1000:1000 /prometheus-pusher /run.sh
 
 USER 1000
 
-ENTRYPOINT ["/bin/sh", "/run.sh"]
+ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
Repalce golang:1.13 with image based on container-registry.oracle.com/os/oraclelinux:7-slim + golang 1.13.3.

Acceptance test: https://build.verrazzano.io/job/verrazzano-remote/job/watsh_bfstest/3/ (passed successfully) using       --set prometheusPusherImage="phx.ocir.io/stevengreenberginc/watsh-prometheus-pusher:1.0.1_6"
